### PR TITLE
init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+coverage/
+tmp/
+npm-debug.log*
+.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+node_js:
+- "0.12"
+- "4"
+sudo: false
+language: node_js
+script: "npm run test:cov"
+after_script: "npm i -g codecov.io && cat ./coverage/lcov.info | codecov"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Tab Digital
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,54 @@
+# node-bunyan-stream [![stability][0]][1]
+[![npm version][2]][3] [![build status][4]][5] [![test coverage][6]][7]
+[![downloads][8]][9] [![js-standard-style][10]][11]
+
+Stream data into a [bunyan][12] logger. Allows fine grained control over what
+is logged from a stream.
+
+## Installation
+```sh
+$ npm install bunyan-stream
+```
+
+## Usage
+```js
+const bunyanStream = require('bunyan-stream')
+const httpNdjson = require('http-ndjson')
+const bunyan = require('bunyan')
+
+const logger = bunyan.createLogger({ name: 'myApp' })
+
+http.createServer((req, res) => {
+  httpNdjson(req, res).pipe(bunyanStream({ level: 'info' }, logger))
+  res.end()
+}).listen()
+```
+
+## API
+### bunyanStream
+Create a new [bunyan][12] writestream (`instanceof through2`). `opts` can
+contain the following values:
+- __level__: the log level. One of `debug`, `info`, `warn`, `error`
+
+## See Also
+- [http-ndjson](https://github.com/TabDigital/http-ndjson)
+- [server-summary](https://github.com/TabDigital/server-summary)
+- [bole-stream](https://github.com/yoshuawuyts/bole-stream)
+- [bunyan][12]
+
+## License
+[MIT](https://tldrlegal.com/license/mit-license)
+
+[0]: https://img.shields.io/badge/stability-experimental-orange.svg?style=flat-square
+[1]: https://nodejs.org/api/documentation.html#documentation_stability_index
+[2]: https://img.shields.io/npm/v/bunyan-stream.svg?style=flat-square
+[3]: https://npmjs.org/package/bunyan-stream
+[4]: https://img.shields.io/travis/TabDigital/node-bunyan-stream/master.svg?style=flat-square
+[5]: https://travis-ci.org/TabDigital/node-bunyan-stream
+[6]: https://img.shields.io/codecov/c/github/TabDigital/node-bunyan-stream/master.svg?style=flat-square
+[7]: https://codecov.io/github/TabDigital/node-bunyan-stream
+[8]: http://img.shields.io/npm/dm/bunyan-stream.svg?style=flat-square
+[9]: https://npmjs.org/package/bunyan-stream
+[10]: https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat-square
+[11]: https://github.com/feross/standard
+[12]: https://github.com/trentm/node-bunyan

--- a/index.js
+++ b/index.js
@@ -1,0 +1,28 @@
+const through = require('through2')
+const json = require('JSONStream')
+const assert = require('assert')
+const pump = require('pump')
+
+module.exports = boleStream
+
+// Stream data into a bole logger
+// (obj?, fn) -> wstream
+function boleStream (opts, logger) {
+  if (!logger) {
+    logger = opts
+    opts = {}
+  }
+
+  assert.equal(typeof opts, 'object')
+  assert.equal(typeof logger, 'object')
+
+  opts.level = opts.level || 'info'
+
+  const ts = json.parse()
+  const ws = through({ objectMode: true }, function (chunk, enc, cb) {
+    logger[opts.level](chunk)
+    cb()
+  })
+
+  return pump(ts, ws)
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "bunyan-stream",
+  "version": "1.0.0",
+  "description": "Stream data into a bunyan logger",
+  "main": "index.js",
+  "scripts": {
+    "deps": "dependency-check . && dependency-check . --extra --no-dev",
+    "test": "standard && npm run deps && NODE_ENV=test node test",
+    "test:cov": "standard && npm run deps && NODE_ENV=test istanbul cover test.js"
+  },
+  "repository": "TabDigital/bunyan-stream",
+  "keywords": [
+    "stream",
+    "bunyan",
+    "ndjson",
+    "log"
+  ],
+  "license": "MIT",
+  "dependencies": {
+    "JSONStream": "^1.0.6",
+    "pump": "^1.0.0",
+    "through2": "^2.0.0"
+  },
+  "devDependencies": {
+    "bl": "^1.0.0",
+    "bunyan": "^1.5.1",
+    "dependency-check": "^2.5.1",
+    "istanbul": "^0.4.0",
+    "standard": "^5.3.1",
+    "tape": "^4.2.2"
+  },
+  "files": [
+    "index.js",
+    "bin/*"
+  ]
+}

--- a/test.js
+++ b/test.js
@@ -1,0 +1,47 @@
+const bunyan = require('bunyan')
+const test = require('tape')
+const bl = require('bl')
+
+const bunyanStream = require('./')
+
+test('should assert input types', function (t) {
+  t.plan(2)
+  t.throws(bunyanStream.bind(null, ''), /object/)
+  t.throws(bunyanStream.bind(null, '', ''), /object/)
+})
+
+test('accept a stream and log data', function (t) {
+  t.plan(3)
+
+  const buf = bl()
+  buf.on('data', function (data) {
+    const obj = JSON.parse(String(data))
+    t.equal(typeof obj, 'object')
+    t.equal(obj.level, 30)
+    t.equal(obj.name, 'bar')
+  })
+
+  const logger = bunyan.createLogger({ stream: buf, name: 'foo' })
+  const ws = bunyanStream(logger)
+  ws.write({ name: 'bar' })
+})
+
+test('allow config', function (t) {
+  t.plan(4)
+
+  const buf = bl()
+  buf.on('data', function (data) {
+    const obj = JSON.parse(String(data))
+    t.equal(typeof obj, 'object')
+    t.equal(obj.level, 50)
+    t.equal(obj.name, 'foo')
+    t.equal(obj.foo, 'bar')
+  })
+
+  const logger = bunyan.createLogger({
+    name: 'foo',
+    stream: buf
+  })
+  const ws = bunyanStream({ level: 'error' }, logger)
+  ws.write({ foo: 'bar' })
+})


### PR DESCRIPTION
Creates a logger adapter that allows streaming of arbitrary [ndjson](http://ghub.io/ndjson) into our logging modules. Makes it easier to interop with existing userland solutions (streaming ndjson loggers, etc.) rather than rewriting / adjusting them. Thanks! 🙌

cc/ @TabDigital/ping-api 
